### PR TITLE
Add GitHub Actions workflows for container image build and push

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,131 @@
+name: Build Container Image
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: 'Push image to registry after build'
+        required: false
+        default: false
+        type: boolean
+      registry:
+        description: 'Container registry path'
+        required: false
+        default: 'ghcr.io/confidential-devhub/staged-images'
+        type: string
+      image_name:
+        description: 'Image name'
+        required: false
+        default: 'coco-tools'
+        type: string
+    secrets:
+      GHCR_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: linux/amd64
+          # To enable multi-arch builds, uncomment entries below and update
+          # the publish-manifest job to include the additional arch tags.
+          # - arch: arm64
+          #   runner: ubuntu-24.04-arm
+          #   platform: linux/arm64
+          # - arch: s390x
+          #   runner: ubuntu-24.04
+          #   platform: linux/s390x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
+
+      - name: Log in to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build (PR verification — no push)
+        if: ${{ !inputs.push }}
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6.16.0
+        with:
+          context: .
+          file: Containerfile
+          push: false
+          platforms: ${{ matrix.platform }}
+          tags: ${{ inputs.registry }}/${{ inputs.image_name }}:${{ github.sha }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Build and push (arch-specific tags)
+        if: ${{ inputs.push }}
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6.16.0
+        with:
+          context: .
+          file: Containerfile
+          push: true
+          platforms: ${{ matrix.platform }}
+          tags: |
+            ${{ inputs.registry }}/${{ inputs.image_name }}:${{ github.sha }}-${{ matrix.arch }}
+            ${{ inputs.registry }}/${{ inputs.image_name }}:latest-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+  publish-manifest:
+    name: Publish Multi-Arch Manifest
+    runs-on: ubuntu-24.04
+    needs: [build]
+    if: ${{ inputs.push }}
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Create and push manifest — commit SHA tag
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE: ${{ inputs.image_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          # List all arch-specific images to include in the manifest.
+          # When adding more architectures to the build matrix above,
+          # append the corresponding arch tag here.
+          SOURCE_IMAGES="${REGISTRY}/${IMAGE}:${SHA}-amd64"
+          # SOURCE_IMAGES="${SOURCE_IMAGES} ${REGISTRY}/${IMAGE}:${SHA}-arm64"
+          # SOURCE_IMAGES="${SOURCE_IMAGES} ${REGISTRY}/${IMAGE}:${SHA}-s390x"
+
+          docker manifest create "${REGISTRY}/${IMAGE}:${SHA}" ${SOURCE_IMAGES}
+          docker manifest push "${REGISTRY}/${IMAGE}:${SHA}"
+
+      - name: Create and push manifest — latest tag
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE: ${{ inputs.image_name }}
+        run: |
+          # Mirror the arch list from the commit SHA manifest step above.
+          SOURCE_IMAGES="${REGISTRY}/${IMAGE}:latest-amd64"
+          # SOURCE_IMAGES="${SOURCE_IMAGES} ${REGISTRY}/${IMAGE}:latest-arm64"
+          # SOURCE_IMAGES="${SOURCE_IMAGES} ${REGISTRY}/${IMAGE}:latest-s390x"
+
+          docker manifest create "${REGISTRY}/${IMAGE}:latest" ${SOURCE_IMAGES}
+          docker manifest push "${REGISTRY}/${IMAGE}:latest"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: read
   packages: write
+  actions: write
 
 jobs:
   build:

--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   packages: read
+  actions: write
 
 jobs:
   build:

--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -1,0 +1,17 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    name: Build image (verification)
+    uses: ./.github/workflows/build-image.yml
+    with:
+      push: false

--- a/.github/workflows/push-image-to-ghcr.yml
+++ b/.github/workflows/push-image-to-ghcr.yml
@@ -10,6 +10,13 @@ permissions:
   packages: write
   actions: write
 
+# Only one run at a time per branch. If a new push arrives while a previous
+# run is still in progress, cancel the older run so the newest commit always
+# wins the "latest" tag.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     name: Build and push image

--- a/.github/workflows/push-image-to-ghcr.yml
+++ b/.github/workflows/push-image-to-ghcr.yml
@@ -1,0 +1,21 @@
+name: Push Image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and push image
+    uses: ./.github/workflows/build-image.yml
+    with:
+      push: true
+      registry: ghcr.io/confidential-devhub/staged-images
+      image_name: coco-tools
+    secrets:
+      GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-image-to-ghcr.yml
+++ b/.github/workflows/push-image-to-ghcr.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   packages: write
+  actions: write
 
 jobs:
   build-and-push:


### PR DESCRIPTION
- pr-build-check.yml: builds image on PR for verification (no push)
- push-image-to-ghcr.yml: builds and pushes image to ghcr.io on merge to main
- build-image.yml: reusable core workflow with matrix build (amd64 only for now, with commented stubs to easily add arm64/s390x) and a manifest job that publishes commit-SHA and latest tags

Image: ghcr.io/confidential-devhub/staged-images/coco-tools

Assisted-by: AI