### PR TITLE
Add skopeo and cosign as veritas prerequisites

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -104,7 +104,13 @@ RUN cp /tdx-measure/cli/target/release/tdx-measure /tools/tdx-measure
 
 FROM quay.io/fedora/fedora:44 AS tools-container
 
-RUN dnf install -y tpm2-tss openssl-libs libgcc zlib-ng-compat
+RUN dnf install -y tpm2-tss openssl-libs libgcc zlib-ng-compat skopeo
+
+ARG COSIGN_VERSION=v3.0.6
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+    curl -sLo /usr/local/bin/cosign \
+        "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-${ARCH}" && \
+    chmod +x /usr/local/bin/cosign
 
 # Install tdx deps from custom copr for now
 RUN dnf install -y tdx-attest-libs

--- a/Containerfile.ubi
+++ b/Containerfile.ubi
@@ -133,9 +133,15 @@ RUN --mount=type=secret,id=org,dst=/run/secrets/org \
     && subscription-manager repos --enable=codeready-builder-for-rhel-10-x86_64-rpms
 
 
-RUN dnf install -y tpm2-tss openssl-libs libgcc zlib
+RUN dnf install -y tpm2-tss openssl-libs libgcc zlib skopeo
 
 RUN subscription-manager unregister
+
+ARG COSIGN_VERSION=v3.0.6
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+    curl -sLo /usr/local/bin/cosign \
+        "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-${ARCH}" && \
+    chmod +x /usr/local/bin/cosign
 
 # Python + oc CLI for veritas (oc adm release info is OpenShift-specific)
 RUN dnf install -y python3 python3-pip git cpio


### PR DESCRIPTION
skopeo and cosign are required by veritas but were missing from the container images. Add skopeo via dnf and cosign via binary download (GitHub releases) for UBI, and both via dnf for Fedora.